### PR TITLE
run the database update asynchronously

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -165,6 +165,7 @@
     clamav_db_update_run and
     clamav_db_age_check_result.rc or
     clamav_db_update_force
+  async: 600
   tags:
     - clamav_db
 


### PR DESCRIPTION
Updating the database can take a while, so better to run it asynchronously to avoid SSH timeout.