### PR TITLE
Eliminate `with_items` loop on package install task.

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -18,8 +18,7 @@
 
 - name: Install ClamAV package
   package:
-    name: "{{ item }}"
-  with_items: "{{ clamav_pkgs }}"
+    name: "{{ clamav_pkgs }}"
   notify:
     - Restart Clamd service
   tags:


### PR DESCRIPTION
Pass `clamav_pkgs` list/array directly to `package.name` instead of using `with_items` loop. Support for this appears to have been added in v2.0 according to the [yum module](http://docs.ansible.com/ansible/yum_module.html) documentation.

Install on Amazon Linux with `clamav_pkgs: [clamd, clamav-update]` fails using `with_items` but succeeds passing the list/array directly;

Before:

```
amazon-ebs: TASK [clamav : Install ClamAV package] *****************************************
amazon-ebs: changed: [127.0.0.1] => (item=clamd)
amazon-ebs: failed: [127.0.0.1] (item=clamav-update) => {"failed": true, "item": "clamav-update", "msg": "Failure talking to yum: [Errno 2] No such file or directory"}
```

After:

```
amazon-ebs: TASK [clamav : Install ClamAV package] *****************************************
amazon-ebs: changed: [127.0.0.1]
 ```

I don't claim to understand what's going on here, but a simpler and more direct way of passing multiple packages seems preferable anyway.

Any thoughts?