### PR TITLE
ClamAV enhancements: network retries, deprecated vars, client-only mode

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -85,7 +85,8 @@ clamav_scan_command_options: "{{
 clamav_scan_command: /usr/bin/clamdscan {{ clamav_scan_command_options | join(' ') }} {{ clamav_scan_root }}
 
 # Whether to setup Clamd Scan cron job
-clamav_scan_cron: yes
+# Superseded by clamav-update package
+clamav_scan_cron: no
 
 # How often to run the Clamd Scan [hourly|daily|weekly]
 clamav_scan_cron_time: daily

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,6 +1,8 @@
 ---
+
 # Whether to install EPEL YUM repo
 clamav_epel_install: "{{ yumrepo_epel_install | default(true) }}"
+
 # EPEL YUM repo URL
 clamav_epel_yumrepo_url: "{{ yumrepo_epel_url | default('https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/') }}"
 
@@ -12,6 +14,12 @@ clamav_epel_yumrepo_params: "{{ yumrepo_epel_params | default({}) }}"
 
 # In the event of network congestion
 clamav_network_max_retries: 0
+
+# ClamAV operating as client-only
+clamav_client_only: false
+
+# Queried clamav version in tasks/main.yml
+clamav_version: 0.999.0
 
 # Package to be installed (explicit version can be specified here)
 clamav_pkgs: "{{
@@ -66,13 +74,14 @@ clamav_scan_command_options__default:
   - --log={{ clamav_scan_log_file }}
   - --fdpass
   - --infected
+  - "{{ clamav_client_only | ternary('--stream', False) }}"
 
 # Default ClamAV scan command options
 clamav_scan_command_options__custom: []
 
 # Default ClamAV scan command options
 clamav_scan_command_options: "{{
-  clamav_scan_command_options__default +
+  clamav_scan_command_options__default | reject('sameas', False) | list +
   clamav_scan_command_options__custom }}"
 
 # ClamAV scan command
@@ -92,7 +101,7 @@ clamav_scan_cron_job: sleep $[RANDOM\%{{ clamav_scan_cron_job_delay }}]m ; {{ cl
 
 
 # Whether to setup FreshClam cron job
-clamav_freshclam_cron: "{{ clamav_scan_cron }}"
+clamav_freshclam_cron: "{{ clamav_scan_cron and not clamav_client_only}}"
 
 # How often to run the Clamd Scan [hourly|daily|weekly]
 clamav_freshclam_cron_time: "{{ clamav_scan_cron_time }}"
@@ -193,7 +202,7 @@ clamav_clamd_log_syslog: "yes"
 clamav_clamd_pid_file: "{{ clamav_run_dir ~ '/clamd.pid' }}"
 clamav_clamd_temporary_directory: /var/tmp
 clamav_clamd_database_directory: /var/lib/clamav
-clamav_clamd_local_socket: "{{ clamav_run_dir ~ '/clamd.sock' }}"
+clamav_clamd_local_socket: "{{ clamav_client_only | ternary(False, clamav_run_dir ~ '/clamd.sock') }}"
 clamav_clamd_fix_stale_socket: "yes"
 clamav_clamd_tcp_socket: 3310
 clamav_clamd_tcp_addr: 127.0.0.1
@@ -233,10 +242,10 @@ clamav_clamd_config__default:
   MaxThreads: "{{ clamav_clamd_max_threads }}"
   ReadTimeout: "{{ clamav_clamd_read_timeout }}"
   User: "{{ clamav_clamd_user }}"
-  AllowSupplementaryGroups: "{{ clamav_clamd_allow_supplementary_groups }}"
+  AllowSupplementaryGroups: "{{ (clamav_version is version('0.100','<')) | ternary(clamav_clamd_allow_supplementary_groups, False) }}"
   ScanPE: "{{ clamav_clamd_scan_pe }}"
   ScanELF: "{{ clamav_clamd_scan_elf }}"
-  DetectBrokenExecutables: "{{ clamav_clamd_detect_broken_executables }}"
+  DetectBrokenExecutables: "{{ (clamav_version is version('0.100','<')) | ternary(clamav_clamd_detect_broken_executables, False) }}"
   ScanOLE2: "{{ clamav_clamd_scan_ole2 }}"
   ScanMail: "{{ clamav_clamd_scan_mail }}"
   ScanArchive: "{{ clamav_clamd_scan_archive }}"
@@ -249,7 +258,7 @@ clamav_clamd_config__custom: {}
 # Final Clamd config
 clamav_clamd_config: "{{
   clamav_clamd_config__default.update(clamav_clamd_config__custom) }}{{
-  clamav_clamd_config__default }}"
+  clamav_clamd_config__default | dict2items | rejectattr('value', 'sameas', False) | list | items2dict }}"
 
 
 # Location of the FreshClam config
@@ -278,4 +287,4 @@ clamav_freshclam_config__custom: {}
 # Final FreshClam config
 clamav_freshclam_config: "{{
   clamav_freshclam_config__default.update(clamav_freshclam_config__custom) }}{{
-  clamav_freshclam_config__default }}"
+  clamav_freshclam_config__default | dict2items | rejectattr('value', 'sameas', False) | list | items2dict }}"

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -18,9 +18,6 @@ clamav_network_max_retries: 0
 # ClamAV operating as client-only
 clamav_client_only: false
 
-# Queried clamav version in tasks/main.yml
-clamav_version: 0.999.0
-
 # Package to be installed (explicit version can be specified here)
 clamav_pkgs: "{{
   ['clamav', 'clamav-update', 'clamav-scanner-systemd']

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,8 +1,6 @@
 ---
-
 # Whether to install EPEL YUM repo
 clamav_epel_install: "{{ yumrepo_epel_install | default(true) }}"
-
 # EPEL YUM repo URL
 clamav_epel_yumrepo_url: "{{ yumrepo_epel_url | default('https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/') }}"
 
@@ -11,6 +9,9 @@ clamav_epel_yumrepo_gpgkey: "{{ yumrepo_epel_gpgkey | default('https://dl.fedora
 
 # Additional EPEL YUM repo params
 clamav_epel_yumrepo_params: "{{ yumrepo_epel_params | default({}) }}"
+
+# In the event of network congestion
+clamav_network_max_retries: 0
 
 # Package to be installed (explicit version can be specified here)
 clamav_pkgs: "{{

--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -7,3 +7,4 @@
   when: >
     clamav_service_started is not defined or
     not clamav_service_started.changed
+    and not clamav_client_only

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -61,9 +61,11 @@
   set_fact: clamav_version="{{ v.stdout }}"
 
 - name: Configure Clamd
-  template:
-    src: clamd.conf.j2
-    dest: "{{ clamav_clamd_file }}"
+  blockinfile:
+    path: "{{ clamav_clamd_file }}"
+    content: "{{ clamav_clamd_config | encode_ini(delimiter=' ') }}"
+    insertbefore: BOF
+    create: yes
   notify:
     - Restart Clamd service
   tags:
@@ -82,18 +84,22 @@
     - clamav_config
 
 - name: Configure Clamd Service
-  template:
-    src: clamd.defaults.j2
-    dest: "{{ clamav_clamd_daemon_file }}"
+  blockinfile:
+    path: "{{ clamav_clamd_daemon_file }}"
+    content: "{{ clamav_clamd_daemon_config | encode_ini }}"
+    insertbefore: BOF
+    create: yes
   notify:
     - Restart Clamd service
   tags:
     - clamav_config
 
 - name: Configure FreshClam
-  template:
-    src: freshclam.conf.j2
-    dest: "{{ clamav_freshclam_file }}"
+  blockinfile:
+    path: "{{ clamav_freshclam_file }}"
+    content: "{{ clamav_freshclam_config | encode_ini(delimiter=' ') }}"
+    insertbefore: BOF
+    create: yes
   tags:
     - clamav_config
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -251,7 +251,7 @@
   tags:
     - clamav_cron
 
-- name: "{{ not clamav_client_only | ternary('Enable', 'Disable') }} ClamAV service"
+- name: "{{ (not clamav_client_only) | ternary('Enable', 'Disable') }} ClamAV service"
   service:
     name: "{{ clamav_service }}"
     enabled: "{{ not clamav_client_only }}"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,5 +1,4 @@
 ---
-
 - name: Test distribution
   assert:
     that: >
@@ -52,6 +51,14 @@
     clamav_selinux_check_result.stdout.find('disabled') == -1
   tags:
     - clamav_selinux
+
+- name: Query clamav version
+  command: clamav-config --version
+  register: v
+  changed_when: false
+
+- name: Set clamav_version
+  set_fact: clamav_version="{{ v.stdout }}"
 
 - name: Configure Clamd
   template:
@@ -247,7 +254,7 @@
 - name: Enable ClamAV service
   service:
     name: "{{ clamav_service }}"
-    enabled: yes
+    enabled: "{{ not clamav_client_only }}"
   tags:
     - clamav_service
 
@@ -256,5 +263,6 @@
     name: "{{ clamav_service }}"
     state: started
   register: clamav_service_started
+  when: not clamav_client_only
   tags:
     - clamav_service

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -13,6 +13,9 @@
     gpgkey: "{{ clamav_epel_yumrepo_gpgkey }}"
     params: "{{ clamav_epel_yumrepo_params }}"
   when: clamav_epel_install == true
+  register: result
+  until: result is succeeded
+  retries: "{{ clamav_network_max_retries }}"
   tags:
     - clamav_pkg
 
@@ -22,6 +25,9 @@
   with_items: "{{ clamav_pkgs }}"
   notify:
     - Restart Clamd service
+  register: result
+  until: result is succeeded
+  retries: "{{ clamav_network_max_retries }}"
   tags:
     - clamav_pkg
 
@@ -214,6 +220,9 @@
     clamav_db_update_run and
     clamav_db_age_check_result.rc or
     clamav_db_update_force
+  register: result
+  until: result is succeeded
+  retries: "{{ clamav_network_max_retries }}"
   tags:
     - clamav_db
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -233,16 +233,16 @@
   tags:
     - clamav_db
 
-- name: Setup Clamd Scan cron job
+- name: "{{ (clamav_scan_cron == true) | ternary('Setup', 'Remove') }} Clamd Scan cron job"
   cron:
     name: Clamd Scan
     special_time: "{{ clamav_scan_cron_time }}"
     job: "{{ clamav_scan_cron_job }}"
-  when: clamav_scan_cron == true
+    state: "{{ (clamav_scan_cron == true) | ternary('present', 'absent') }}"
   tags:
     - clamav_cron
 
-- name: Setup FreshClam cron job
+- name: "{{ (clamav_freshclam_cron == true) | ternary('Setup', 'Remove') }} FreshClam cron job"
   cron:
     name: FreshClam
     special_time: "{{ clamav_freshclam_cron_time }}"
@@ -251,7 +251,7 @@
   tags:
     - clamav_cron
 
-- name: Enable ClamAV service
+- name: "{{ not clamav_client_only | ternary('Enable', 'Disable') }} ClamAV service"
   service:
     name: "{{ clamav_service }}"
     enabled: "{{ not clamav_client_only }}"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -247,7 +247,7 @@
     name: FreshClam
     special_time: "{{ clamav_freshclam_cron_time }}"
     job: "{{ clamav_freshclam_cron_job }}"
-  when: clamav_freshclam_cron == true
+    state: "{{ (clamav_freshclam_cron == true) | ternary('present', 'absent') }}"
   tags:
     - clamav_cron
 

--- a/templates/clamd.conf.j2
+++ b/templates/clamd.conf.j2
@@ -1,3 +1,0 @@
-{{ ansible_managed | comment }}
-
-{{ clamav_clamd_config | encode_ini(delimiter=' ') }}

--- a/templates/clamd.defaults.j2
+++ b/templates/clamd.defaults.j2
@@ -1,3 +1,0 @@
-{{ ansible_managed | comment }}
-
-{{ clamav_clamd_daemon_config | encode_ini }}

--- a/templates/freshclam.conf.j2
+++ b/templates/freshclam.conf.j2
@@ -1,3 +1,0 @@
-{{ ansible_managed | comment }}
-
-{{ clamav_freshclam_config | encode_ini(delimiter=' ') }}


### PR DESCRIPTION
Hello,

This adds a few additional features:

- Allow multiple retries for network-dependent tasks by setting clamav_network_max_retries (default: 0).
- Client-only mode that installs ClamAV without daemon activation. This can be effected by setting for example clamav_clamd_tcp_addr=1.2.2.1, clamav_client_only=true. So long as firewall rules permit, all scans will dispatch scans using ClamAV's INSTREAM protocol.
- Ignoring deprecated vars that went into effect in [0.100](https://blog.clamav.net/2018/04/clamav-01000-has-been-released.html), AllowSupplementaryGroups and DetectBrokenExecutables. A new variable is introduced, clamav_version that is updated once it's known ClamAV is installed.
- It's now possible to skip templating of a ClamAV variable by setting its value to `False`.
- FreshClam cron is now disabled with presence of client-only mode.

**Edit**: to note, the `False` templating value is used in ternary() tasks where `None` would be converted to an empty string. I see from #6 that it's possible to omit a value, but only if the value is literally `null`; `ternary(None)` would become a blank string.